### PR TITLE
feat: add vicinae launcher, replace walker on SUPER+SPACE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ tiling-assistant/
 user-dirs.dirs
 user-dirs.locale
 
+# Vicinae: GUI-mutable runtime state, per-machine
+vicinae/settings.json
+

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ ln -sf ~/dotfiles/tmux ~/.config/
 ln -sf ~/dotfiles/hypr ~/.config/
 ln -sf ~/dotfiles/waybar ~/.config/
 
+# App launcher (Arch) — vicinae replaces walker on SUPER+SPACE
+ln -sf ~/dotfiles/vicinae ~/.config/
+
 # Window manager (macOS)
 ln -sf ~/dotfiles/aerospace ~/.config/
 
@@ -61,6 +64,7 @@ source ~/.bashrc   # or: source ~/.zshrc
 | **aerospace** | Tiling window manager (macOS) |
 | **hypr** | Hyprland compositor config (Arch / Omarchy) — gaps, rounding, workspace anims, SUPER+TAB last-active |
 | **waybar** | Status bar config — black pill theme, workspace window icons |
+| **vicinae** | Vicinae launcher (Arch) — Raycast-like, bound to SUPER+SPACE via AUR `vicinae-bin` |
 | **wallpapers** | Desktop wallpapers (applied via `swww` on Omarchy) |
 | **.idea** | IdeaVim config for JetBrains IDEs |
 | **.vscode** | VSCode Vim keybindings and editor settings |

--- a/hypr/autostart.conf
+++ b/hypr/autostart.conf
@@ -1,2 +1,5 @@
 # Extra autostart processes
 # exec-once = uwsm-app -- my-service
+
+# Vicinae launcher daemon
+exec-once = uwsm-app -- vicinae server

--- a/hypr/bindings.conf
+++ b/hypr/bindings.conf
@@ -22,6 +22,10 @@ bind = SUPER SHIFT, S, exec, omarchy-capture-screenshot      # Print Screen Butt
 bind = SUPER, H, exec, voxtype record toggle                 # Dictation Button
 bind = SUPER, PERIOD, exec, omarchy-launch-walker -m symbols # Emoji Button
 
+# Launcher: replace omarchy walker on SUPER+SPACE with vicinae
+unbind = SUPER, SPACE
+bindd = SUPER, SPACE, Vicinae launcher, exec, vicinae toggle
+
 # Window switching
 # Override omarchy defaults: SUPER,TAB=Next workspace and SUPER+SHIFT,TAB=Previous workspace
 unbind = SUPER, TAB

--- a/vicinae/config.json
+++ b/vicinae/config.json
@@ -1,0 +1,217 @@
+{
+	"$schema": "https://vicinae.com/schemas/config.json",
+
+	// A list of paths pointed to separate configuration files to source during loading.
+	// Note that values defined in the main configuration file always take precedence over imported
+	// files.
+	// Relative paths are accepted, and are relative to the configuration directory in which the importing configuration file is located.
+	"imports": [
+		// "./keybinds.json"
+		// "./providers.json"
+	],
+
+	// Choose what telemetry to sent to the vicinae central server
+	// We never send personally identifiable information
+	// More details available at https://docs.vicinae.com/telemetry
+	"telemetry": {
+		// Sends system information such as desktop environment, vicinae version, etc...
+		// Only sent once at startup every 24 hours
+		"system_info": true
+	},
+
+	// Input monitoring/injection binary required to handle "paste to active window" actions and snippet expansion.
+	// If disabled, Vicinae will automatically fallback on copy instead of paste, and keyword expansion for snippets will no longer work.
+	// Note that conceptually, the input server is not uniquely related to snippets, so disabling snippets will not shutdown the input server process:
+	// only this key can.
+	"input_server": {
+		"enabled": true
+	},
+
+	// Whether root search should also search files directly.
+	// File search is performed asynchrounously: files may take an instant to appear after a query is entered.
+	// Turning this on results in an increase in CPU usage when searching.
+	// Note that vicinae has a built-in file search command that can be used to perform file search in isolation, accompanied with
+	// rich content preview. This should be more than enough for most users.
+	"search_files_in_root": false,
+
+	// activate list and grid items with only one click
+	"activate_on_single_click": false,
+
+	// What vicinae should do when the "escape" key is pressed
+	// Supports "navigate_back" or "close_window"
+	"escape_key_behavior": "navigate_back",
+
+	// navigate back when backspace is pressed on an empty search input
+	"pop_on_backspace": true,
+
+	// If the layer shell protocol is used to position the window and the keyboard interactivity is
+	// set to "exclusive" (the default) then this setting will have no effect. Either switch to "on_demand" interactivity
+	// or disable layer shell.
+	"close_on_focus_loss": false,
+
+	// Whether IME preedit strings should be searched in real time.
+	"consider_preedit": false,
+
+	// Reset the navigation state every time the window is closed
+	"pop_to_root_on_close": false,
+
+	// What favicon service to use when loading favicons is needed.
+	// Available values are: 'twenty' | 'google' | 'none'
+	// If this is set to 'none', favicon loading is disabled and a placeholder icon will be used when a favicon is expected.
+	"favicon_service": "twenty",
+
+	// EXPERIMENTAL!
+	// Enable specific editing motions in the main search bar and during navigation.
+	// This will probably be changed in future updates.
+	// Supports: 'default' | 'emacs'
+	"keybinding": "default",
+
+	"font": {
+		// Text rendering backend used by Qt Quick text.
+		// "native": uses platform/fontconfig rendering (can have better dark-mode weight/clarity)
+		// "qt": uses Qt distance-field rendering (typically better performance for heavy scaling/animation)
+		"rendering": "qt",
+
+		// The font family to use for the general vicinae UI.
+		// "auto" (recommended): uses the bundled Inter font
+		// "system": uses the system/platform default font
+		// Or specify any font family name (e.g. "Fira Sans")
+		"normal": {
+			"family": "auto",
+			// The point size of the font (unlike pixel size, the point size scales with resolution)
+			"size": 10.5
+		}
+	},
+
+	// The general vicinae theme as well as the system icon theme (used for applications and file icons) can be customized
+	// according to the system appearance.
+	// When editing the current theme through the vicinae GUI, it will modify the value that maps to the current system appearance.
+	"theme": {
+		"light": {
+			"name": "vicinae-light",
+			"icon_theme": "auto"
+		},
+		"dark": {
+			"name": "vicinae-dark",
+			"icon_theme": "auto"
+		}
+	},
+
+	"launcher_window": {
+		// Control the opacity of the main window.
+		// Opacity for other surfaces are controlled by the active theme.
+		// [0;1]
+		"opacity": 1.0,
+		
+		// Blur the window background.
+		// Supported on wayland compositors that implement ext-background-effect
+		// Make sure the window opacity above is < 1
+		"blur": {
+			"enabled": true
+		},
+
+		// You can turn client side decorations off if you want to let your compositor draw the rounded
+		// borders and such. This usually gives better results, but is more complicated to setup, if at all possible.
+		"client_side_decorations": {
+			"enabled": true,
+			"rounding": 10,
+			"border_width": 1,
+
+			// Draws drop shadows on the client side, ONLY if we are a layer surface.
+			// We assume that non layer surfaces may already have drop shadows drawn by the compositor.
+			// In order to play well with blur, we do NOT allow drop shadows if the compositor doesn't support
+			// the ext-background-effect protocol (which allows defining a specific region to blur).
+			"shadow_size": 12
+		},
+
+		// In compact mode, vicinae only shows a search bar in the root search if no query is entered, only expanding to its full size when searching.
+		// WARNING: compact mode works best when vicinae is rendered as a layer surface (the default if available), as opposed to a regular floating window.
+		"compact_mode": {
+			"enabled": false
+		},
+
+		// The vicinae UI is designed to work best at the default size. If you change this it is highly recommended
+		// that you preserve a similar aspect ratio.
+		"size": {
+			"width": 770,
+			"height": 480
+		},
+
+		// EXPERIMENTAL - X11 ONLY!
+		// The name of the screen (as provided by a tool like xrandr) on which the vicinae window
+		// needs to be shown.
+		// e.g "eDP1", "DP-1"
+		"screen": "auto",
+
+		// Only for wayland compositors that support the 'wlr-layer-shell' protocol (https://wayland.app/protocols/wlr-layer-shell-unstable-v1)
+		// NOTE: layer shell support for the cosmic compositor is explicitly disabled as it is currently broken
+		"layer_shell": {
+			"enabled": true,
+
+			// 'exclusive' | 'on_demand'
+			// WARNING: 'exclusive' is known to break mouse stuff on popups (such as the action panel) on Hyprland
+			"keyboard_interactivity": "exclusive",
+
+			// either 'overlay' or 'top'.
+			// Other layers are not supported as they are unsuitable for a launcher.
+			// 'top' is recommended as using 'overlay' will make the vicinae window appear on top of IME popovers in some scenarios.
+			"layer": "top" 
+		}
+	},
+
+	// How much memory (in MB) can be used to cache small image assets in memory directly
+	// The higher this value is the more memory vicinae will use. In exchange for this, you get lower cpu usage.
+	"pixmap_cache_mb": 50,
+
+	// Keybinds are serialized using a custom format.
+	// It is recommended to edit them through the settings GUI, which will write them to this file.
+	"keybinds": {
+		// common shortcuts
+		"open-search-filter": "control+P",
+		"open-settings": "control+,",
+		"toggle-action-panel": "control+B",
+
+		// used to assign shortcuts to generic actions
+		// if an extension provides a specific kind of action, it is encouraged to use shortcuts as defined here.
+		"action.copy": "control+shift+C",
+		"action.copy-name": "control+shift+.",
+		"action.copy-path": "control+shift+,",
+		"action.dangerous-remove": "control+shift+X",
+		"action.duplicate": "control+D",
+		"action.edit": "control+E",
+		"action.edit-secondary": "control+shift+E",
+		"action.move-down": "control+shift+ARROWDOWN",
+		"action.move-up": "control+shift+ARROWUP",
+		"action.new": "control+N",
+		"action.open": "control+O",
+		"action.pin": "control+shift+P",
+		"action.refresh": "control+R",
+		"action.remove": "control+X",
+		"action.save": "control+S"
+	},
+
+	// List of entrypoints that are tagged as "favorite".
+	// They show up on the very top of the root search when no search query is active.
+	// Each value is a serialized entrypoint ID.
+	"favorites": [
+		"clipboard:history"
+	],
+
+	// List of entrypoints to suggest as a fallback when no result matches the
+	// provided search query.
+	// Each value is a serialized entrypoint ID.
+	"fallbacks": [
+		"files:search"
+	],
+
+	// Every item that can be activated from the vicinae root search is referred as an entrypoint, or sometimes, in the case of extensions, as a "command".
+	// Entrypoints are always grouped under a provider.
+	// e,g applications entrypoints are all grouped under the "applications" provider
+	//
+	// The best way to interact with providers and entrypoints is through the graphical interface provided by the
+	// settings window ("extensions" tab). Every time a change is made through this GUI, the relevant values will be
+	// written to the "providers" object below (password preferences excluded).
+	//
+	// The exact list of available providers depends on what extensions have been installed.
+	"providers": {}
+}


### PR DESCRIPTION
## Summary
- Install **vicinae** (Raycast-like launcher) from AUR `vicinae-bin` and wire it into Hyprland
- Tracked config: `vicinae/config.json` (upstream JSONC template — edit-source-of-truth); `vicinae/settings.json` gitignored (GUI-mutable runtime state)
- Hypr autostart spawns `vicinae server`; `SUPER+SPACE` unbound from omarchy walker and rebound to `vicinae toggle`. Walker emoji bind on `SUPER+.` untouched.

## Setup on a fresh machine
```bash
yay -S vicinae-bin
ln -sf ~/dotfiles/vicinae ~/.config/
hyprctl reload
```

## Test plan
- [ ] `pgrep vicinae` shows daemon after Hyprland start
- [ ] `SUPER+SPACE` opens vicinae
- [ ] `SUPER+.` still opens walker emoji picker
- [ ] `~/.config/vicinae` is a symlink to `~/dotfiles/vicinae`
- [ ] GUI tweaks land in `settings.json` and stay out of git (gitignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)