### PR TITLE
feat(tmux): open new windows in current pane directory

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -21,6 +21,9 @@ setw -g mode-keys vi
 bind-key -T copy-mode-vi v send-keys -X begin-selection
 bind-key -T copy-mode-vi y send-keys -X copy-selection-and-cancel
 
+# Open new windows in the current pane's directory
+bind c new-window -c "#{pane_current_path}"
+
 # Split panes using | and -
 bind | split-window -h -c "#{pane_current_path}"
 bind - split-window -v -c "#{pane_current_path}"


### PR DESCRIPTION
## What

Bind `prefix + c` (your prefix is `Ctrl+Space`) to `new-window -c "#{pane_current_path}"` so a newly created window starts in the **same directory** you're currently in, instead of `$HOME`.

## Why

The config already opens splits in the current directory (`bind |` / `bind -`), but plain `c` used tmux's default, which drops you back to your home dir. This makes new windows consistent with panes.

## How to test

Reload config (`prefix + r`), `cd` into any directory, hit `Ctrl+Space` then `c`, and run `pwd` in the new window — it should match.

Source: [DJ Adams — New tmux panes and windows in the right directory](https://qmacro.org/blog/posts/2021/04/01/new-tmux-panes-and-windows-in-the-right-directory/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)