### PR TITLE
feat(nvim): add Docker and Docker Compose LSP support

### DIFF
--- a/nvim/lua/lsp.lua
+++ b/nvim/lua/lsp.lua
@@ -18,7 +18,9 @@ require("mason-lspconfig").setup({
 		"terraformls",
 		"ruff",
 		"clangd",
-		"protols"
+		"protols",
+		"dockerls",
+		"docker_compose_language_service",
 	},
 	automatic_installation = true,
 })
@@ -232,6 +234,34 @@ vim.lsp.config.ballerina = {
 	on_attach = on_attach,
 }
 vim.lsp.enable("ballerina")
+
+-- Dockerfile LSP (dockerfile-language-server-nodejs)
+vim.lsp.config.dockerls = {
+	cmd = { "docker-langserver", "--stdio" },
+	filetypes = { "dockerfile" },
+	root_markers = { "Dockerfile", ".git" },
+	capabilities = capabilities,
+	on_attach = on_attach,
+}
+vim.lsp.enable("dockerls")
+
+-- Docker Compose LSP (attaches to compose files detected as yaml.docker-compose)
+vim.lsp.config.docker_compose_language_service = {
+	cmd = { "docker-compose-langserver", "--stdio" },
+	filetypes = { "yaml.docker-compose" },
+	root_markers = { "docker-compose.yaml", "docker-compose.yml", "compose.yaml", "compose.yml", ".git" },
+	capabilities = capabilities,
+	on_attach = on_attach,
+}
+vim.lsp.enable("docker_compose_language_service")
+
+-- Detect docker-compose files so the compose LSP attaches (yaml LSP would otherwise grab them)
+vim.filetype.add({
+	pattern = {
+		["[Dd]ocker%-?[Cc]ompose.*%.ya?ml"] = "yaml.docker-compose",
+		["[Cc]ompose.*%.ya?ml"] = "yaml.docker-compose",
+	},
+})
 
 vim.lsp.enable("bashls")
 

--- a/nvim/lua/plugins/treesitter.lua
+++ b/nvim/lua/plugins/treesitter.lua
@@ -1,5 +1,5 @@
 local languages = {
-	"bash", "c", "cpp", "css", "go", "gomod", "gosum", "gowork",
+	"bash", "c", "cpp", "css", "dockerfile", "go", "gomod", "gosum", "gowork",
 	"html", "javascript", "json", "lua", "markdown", "markdown_inline",
 	"python", "query", "rust", "typescript", "vim", "vimdoc", "yaml",
 }


### PR DESCRIPTION
## Summary
Adds Docker language support to the Neovim config so Dockerfiles and Compose files get autocompletion, hover, and diagnostics.

## Changes
- **`nvim/lua/lsp.lua`**
  - Add `dockerls` (dockerfile-language-server-nodejs) and `docker_compose_language_service` to Mason's `ensure_installed` for auto-install.
  - Configure & enable `dockerls` for the `dockerfile` filetype.
  - Configure & enable `docker_compose_language_service` for Compose files.
  - Add a `vim.filetype.add` rule tagging `docker-compose*.yml` / `compose*.yml` as `yaml.docker-compose` so the Compose LSP attaches (instead of plain yaml).
- **`nvim/lua/plugins/treesitter.lua`**
  - Add the `dockerfile` treesitter grammar for syntax highlighting (yaml already present for Compose).

## Notes
Both servers install via Mason on next launch. Verify with `:LspInfo` in a `Dockerfile` and a `docker-compose.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfMZ1KWH5WmvyWvXaL5g1W