### PR TITLE
feat(nvim): add Jinja2 and XML syntax highlighting

### DIFF
--- a/nvim/lua/options.lua
+++ b/nvim/lua/options.lua
@@ -12,4 +12,11 @@ vim.opt.completeopt = { "menu", "menuone", "noselect" }
 vim.opt.clipboard = "unnamedplus"
 vim.opt.autoread = true
 
-vim.filetype.add({ extension = { bal = "ballerina" } })
+vim.filetype.add({
+	extension = {
+		bal = "ballerina",
+		j2 = "jinja",
+		jinja = "jinja",
+		jinja2 = "jinja",
+	},
+})

--- a/nvim/lua/plugins/treesitter.lua
+++ b/nvim/lua/plugins/treesitter.lua
@@ -1,7 +1,8 @@
 local languages = {
 	"bash", "c", "cpp", "css", "dockerfile", "go", "gomod", "gosum", "gowork",
-	"html", "javascript", "json", "lua", "markdown", "markdown_inline",
-	"python", "query", "rust", "typescript", "vim", "vimdoc", "yaml",
+	"html", "javascript", "jinja", "jinja_inline", "json", "lua", "markdown",
+	"markdown_inline", "python", "query", "rust", "typescript", "vim", "vimdoc",
+	"xml", "yaml",
 }
 
 local install_dir = vim.fn.stdpath("data") .. "/site"
@@ -9,7 +10,8 @@ local install_dir = vim.fn.stdpath("data") .. "/site"
 local indent_langs = {
 	bash = true, c = true, cpp = true, css = true, go = true,
 	html = true, javascript = true, json = true, lua = true,
-	python = true, query = true, rust = true, typescript = true, vim = true, yaml = true,
+	python = true, query = true, rust = true, typescript = true, vim = true,
+	xml = true, yaml = true,
 }
 
 local function configure()


### PR DESCRIPTION
## Summary
- Add `jinja`, `jinja_inline`, and `xml` treesitter parsers to the installed language list
- Map `.j2`, `.jinja`, and `.jinja2` extensions to the `jinja` filetype
- Enable treesitter indent for XML

## Testing
- Parsers install cleanly via headless `ts.install` (4/4 languages)
- Opening a `.j2` file detects `filetype=jinja` with the treesitter highlighter active

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESnUEm2W79nb72A9Vqvd1Y