### PR TITLE
feat(tmux): bind prefix+b to previous-window

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -42,6 +42,9 @@ bind -r Down resize-pane -D
 bind -r Left resize-pane -L
 bind -r Right resize-pane -R
 
+# Window navigation: n = next, b = back
+bind b previous-window
+
 # Easy config reload
 bind r source-file ~/.tmux.conf \; display "Configuration reloaded!"
 


### PR DESCRIPTION
Adds `bind b previous-window` so window navigation is symmetric: `prefix+n` = next window, `prefix+b` = back a window. `prefix+b` was previously unbound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zQgxZdEX1Cy9xRTeHW57a