### PR TITLE
feat(hypr): bind Super+M to maximize window

### DIFF
--- a/hypr/bindings.conf
+++ b/hypr/bindings.conf
@@ -33,3 +33,6 @@ unbind = SUPER, TAB
 unbind = SUPER SHIFT, TAB
 bindd = SUPER, TAB, Toggle last active window, focuscurrentorlast
 bindd = SUPER SHIFT, code:23, Cycle to previous window, cyclenext, prev
+
+# Maximize window (keeps bar and gaps, unlike SUPER+F full screen)
+bindd = SUPER, M, Maximize window, fullscreen, 1


### PR DESCRIPTION
Adds `bindd = SUPER, M, Maximize window, fullscreen, 1` to `hypr/bindings.conf`.

Fullscreen mode 1 maximizes the window within the workspace — the bar and gaps stay visible — unlike Super+F / Shift+F11 (fullscreen mode 0, true fullscreen).

Super+M was unbound in this setup (Omarchy's default Super+M music binding is not sourced here; Spotify is on Super+Shift+M). Validated with `hyprctl reload` + `hyprctl configerrors` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)