### PR TITLE
Autostart apps on assigned workspaces at login

### DIFF
--- a/hypr/autostart.conf
+++ b/hypr/autostart.conf
@@ -4,3 +4,10 @@ exec-once = swaync
 
 # Vicinae launcher daemon
 exec-once = uwsm-app -- vicinae server
+
+# Workspace app layout at login
+exec-once = [workspace 1 silent] uwsm-app -- ghostty
+exec-once = [workspace 2 silent] uwsm-app -- zen-browser
+exec-once = [workspace 3 silent] uwsm-app -- obsidian
+exec-once = [workspace 4 silent] uwsm-app -- spotify
+exec-once = [workspace 5 silent] uwsm-app -- slack


### PR DESCRIPTION
Adds `exec-once = [workspace N silent] uwsm-app -- <app>` lines to `hypr/autostart.conf` so Hyprland launches apps on fixed workspaces at login:

1. ghostty
2. zen-browser
3. obsidian
4. spotify
5. slack

`silent` keeps focus from jumping between workspaces during startup. Validated with `hyprctl reload` + `hyprctl configerrors` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLh942WF4Uxqh6HgDBvXP1