### PR TITLE
fix(pi): respect approve and hide filechanges widget

### DIFF
--- a/pi/agent/extensions/filechanges/index.ts
+++ b/pi/agent/extensions/filechanges/index.ts
@@ -167,7 +167,7 @@ export default function (pi: ExtensionAPI) {
 		if (!ctx?.hasUI) return;
 
 		ctx.ui.setStatus("filechanges", formatStatus(tracked, ctx.ui.theme));
-		ctx.ui.setWidget("filechanges", buildWidgetLines(tracked, ctx.ui.theme));
+		ctx.ui.setWidget("filechanges", undefined);
 	}
 
 	async function recomputeTrackedFile(ctx: any, relPath: string) {

--- a/pi/agent/npm/package.json
+++ b/pi/agent/npm/package.json
@@ -1,6 +1,10 @@
 {
   "name": "pi-extensions",
   "private": true,
+  "scripts": {
+    "postinstall": "patch-package",
+    "test:permission-approve": "bun test ./node_modules/@gotgenes/pi-permission-system/test/approve-mode.test.ts"
+  },
   "dependencies": {
     "@gotgenes/pi-permission-system": "^24.0.0",
     "@juicesharp/rpiv-todo": "^2.4.0",
@@ -23,5 +27,8 @@
     "pi-opencode-bridge": "^0.2.1",
     "shell-quote": "^1.8.4",
     "unpdf": "^1.4.0"
+  },
+  "devDependencies": {
+    "patch-package": "^8.0.1"
   }
 }

--- a/pi/agent/npm/patches/@gotgenes+pi-permission-system+24.0.0.patch
+++ b/pi/agent/npm/patches/@gotgenes+pi-permission-system+24.0.0.patch
@@ -1,0 +1,53 @@
+diff --git a/node_modules/@gotgenes/pi-permission-system/src/extension-config.ts b/node_modules/@gotgenes/pi-permission-system/src/extension-config.ts
+index 50365ba..2a24c34 100644
+--- a/node_modules/@gotgenes/pi-permission-system/src/extension-config.ts
++++ b/node_modules/@gotgenes/pi-permission-system/src/extension-config.ts
+@@ -88,9 +88,15 @@ export function normalizePermissionSystemConfig(
+ 
+ export function isYoloModeEnabled(
+   config: PermissionSystemExtensionConfig,
++  argv: readonly string[] = process.argv,
+ ): boolean {
+   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-conversion -- typed as boolean but may be undefined at runtime (untyped callers); Boolean() guards against that
+-  return Boolean(config.yoloMode);
++  let enabled = Boolean(config.yoloMode);
++  for (const arg of argv) {
++    if (arg === "--approve" || arg === "-a") enabled = true;
++    else if (arg === "--no-approve" || arg === "-na") enabled = false;
++  }
++  return enabled;
+ }
+ 
+ export function ensurePermissionSystemLogsDirectory(
+diff --git a/node_modules/@gotgenes/pi-permission-system/test/approve-mode.test.ts b/node_modules/@gotgenes/pi-permission-system/test/approve-mode.test.ts
+new file mode 100644
+index 0000000..05a9c84
+--- /dev/null
++++ b/node_modules/@gotgenes/pi-permission-system/test/approve-mode.test.ts
+@@ -0,0 +1,26 @@
++import assert from "node:assert/strict";
++import test from "node:test";
++
++import {
++  DEFAULT_EXTENSION_CONFIG,
++  isYoloModeEnabled,
++} from "../src/extension-config.ts";
++
++test("--approve enables yolo mode", () => {
++  assert.equal(
++    isYoloModeEnabled(DEFAULT_EXTENSION_CONFIG, ["node", "pi", "--approve"]),
++    true,
++  );
++});
++
++test("the last approval flag wins", () => {
++  assert.equal(
++    isYoloModeEnabled(DEFAULT_EXTENSION_CONFIG, [
++      "node",
++      "pi",
++      "--approve",
++      "--no-approve",
++    ]),
++    false,
++  );
++});


### PR DESCRIPTION
`pi --approve` now auto-approves permission-system prompts while preserving normal prompts and last-flag-wins behavior for `--no-approve`. The patch is reapplied after npm installs and includes focused regression coverage.

The filechanges extension also stops rendering its changed-file list above the editor. Tracking, status, diff inspection, accept, and decline commands remain unchanged.
