### PR TITLE
feat(hypr): OpenCode desktop on workspace 4 at login

### DIFF
--- a/hypr/windows.lua
+++ b/hypr/windows.lua
@@ -7,12 +7,13 @@
 --
 -- Workspace numbers follow the layout used by the autostart script. Note this
 -- differs from aerospace.toml, which puts Spotify on 7 (with Cron on 8 and
--- WhatsApp on 9); the Linux box uses 4 and 5 for Spotify and Slack.
+-- WhatsApp on 9); the Linux box uses 5 and 6 for Spotify and Slack.
 --
 -- Class names come from each app's StartupWMClass / hyprctl clients.
 
 o.window("com.mitchellh.ghostty", { workspace = "1" })
 o.window("^zen$",                 { workspace = "2" })
 o.window("md.Obsidian",           { workspace = "3" })
-o.window("^spotify$",             { workspace = "4" })
-o.window("^Slack$",               { workspace = "5" })
+o.window("ai.opencode.desktop",   { workspace = "4" })
+o.window("^spotify$",             { workspace = "5" })
+o.window("^Slack$",               { workspace = "6" })

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,8 +22,9 @@ Opens the standard app-per-workspace layout at login:
 | 1 | ghostty |
 | 2 | zen-browser |
 | 3 | obsidian |
-| 4 | spotify |
-| 5 | slack |
+| 4 | opencode desktop |
+| 5 | spotify |
+| 6 | slack |
 
 Wired up from `hypr/autostart.lua` via `o.exec_on_start()`, so it runs on every
 Hyprland start. Safe to run by hand too:

--- a/scripts/omarchy-workspace-autostart.sh
+++ b/scripts/omarchy-workspace-autostart.sh
@@ -14,8 +14,9 @@ LAYOUT=(
   "1:ghostty:ghostty"
   "2:zen-browser:zen-browser"
   "3:obsidian:obsidian"
-  "4:spotify:spotify"
-  "5:slack:slack"
+  "4:/opt/OpenCode/ai.opencode.desktop:/opt/OpenCode/ai.opencode.desktop"
+  "5:spotify:spotify"
+  "6:slack:slack"
 )
 
 log() { printf '[workspace-autostart] %s\n' "$*" >&2; }
@@ -34,12 +35,14 @@ done
 launch() {
   local ws=$1 bin=$2 cmd=$3
 
-  if ! command -v "$bin" >/dev/null 2>&1; then
+  local proc=${bin##*/}
+
+  if ! command -v "$bin" >/dev/null 2>&1 && [[ ! -x "$bin" ]]; then
     log "skip workspace $ws: '$bin' is not installed"
     return
   fi
 
-  if pgrep -x "$bin" >/dev/null 2>&1; then
+  if pgrep -x "$proc" >/dev/null 2>&1; then
     log "skip workspace $ws: '$bin' is already running"
     return
   fi


### PR DESCRIPTION
## Summary
- Login autostart order is now Ghostty → Zen → Obsidian → OpenCode desktop → Spotify → Slack
- Window rules match that layout so apps opened later land on the same workspaces

## Test plan
- [ ] Relogin (or run `~/.dotfiles/scripts/omarchy-workspace-autostart.sh`) and confirm workspace assignment
- [ ] Confirm OpenCode desktop is skipped cleanly if already running / not installed